### PR TITLE
scripts: use apt-get instead of apt

### DIFF
--- a/scripts/add-and-pin-repo.sh
+++ b/scripts/add-and-pin-repo.sh
@@ -34,9 +34,9 @@ if [ "$#" != 0 ]; then
     exit 1
 fi
 
-apt update
-apt upgrade -y --allow-downgrades
-apt autoremove -y
+apt-get update
+apt-get upgrade -y --allow-downgrades
+apt-get autoremove -y
 
 # Undo changes to work around debos fakemachine resolver
 rm /etc/resolv.conf

--- a/scripts/add-android9-repos.sh
+++ b/scripts/add-android9-repos.sh
@@ -23,17 +23,17 @@ if [ "$CHANNEL" == "edge" ]; then
     echo "Pin-Priority: 2020" >> /etc/apt/preferences.d/ubports-android9.pref
 fi
 
-apt update
-apt upgrade -y --allow-downgrades
+apt-get update
+apt-get upgrade -y --allow-downgrades
 
-apt install -y bluebinder ofono-ril-binder-plugin pulseaudio-modules-droid-28
+apt-get install -y bluebinder ofono-ril-binder-plugin pulseaudio-modules-droid-28
 # sensorfw
-apt remove -y qtubuntu-sensors
-apt install -y libsensorfw-qt5-hybris libsensorfw-qt5-configs libsensorfw-qt5-plugins libqt5sensors5-sensorfw qtubuntu-position
+apt-get remove -y qtubuntu-sensors
+apt-get install -y libsensorfw-qt5-hybris libsensorfw-qt5-configs libsensorfw-qt5-plugins libqt5sensors5-sensorfw qtubuntu-position
 # hfd-service
-apt install -y hfd-service libqt5feedback5-hfd hfd-service-tools
+apt-get install -y hfd-service libqt5feedback5-hfd hfd-service-tools
 # in-call audio
-apt install -y pulseaudio-modules-droid-hidl-28 audiosystem-passthrough
+apt-get install -y pulseaudio-modules-droid-hidl-28 audiosystem-passthrough
 
 # Restore symlink
 rm /etc/resolv.conf

--- a/scripts/add-mainline-repos.sh
+++ b/scripts/add-mainline-repos.sh
@@ -29,11 +29,11 @@ echo "Pin: origin repo.ubports.com" >> /etc/apt/preferences.d/ubports.pref
 echo "Pin: release o=UBports,a=xenial_-_edge_-_wayland" >> /etc/apt/preferences.d/ubports.pref
 echo "Pin-Priority: 2002" >> /etc/apt/preferences.d/ubports.pref
 
-apt update
-apt upgrade -y --allow-downgrades
-apt autoremove -y
+apt-get update
+apt-get upgrade -y --allow-downgrades
+apt-get autoremove -y
 
-apt install ubuntu-touch-session-wayland libgbm1 libgl1-mesa-dri hfd-service libqt5feedback5-hfd -y
+apt-get install ubuntu-touch-session-wayland libgbm1 libgl1-mesa-dri hfd-service libqt5feedback5-hfd -y
 
 # Undo changes to work around debos fakemachine resolver
 rm /etc/resolv.conf

--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -9,8 +9,8 @@ echo "nameserver 1.1.1.1" > /etc/resolv.conf
 export DEBIAN_FRONTEND=noninteractive
 export DEBCONF_NONINTERACTIVE_SEEN=true
 
-apt update
-apt install -y "$@"
+apt-get update
+apt-get install -y "$@"
 
 # Undo changes to work around debos fakemachine resolver
 rm /etc/resolv.conf


### PR DESCRIPTION
There're 2 reasons for this:
- apt doesn't make a promise about backward-compatibility. apt-get does
  (IIRC). Thus, it's better to use apt-get in scripts.
- For some reason, debos seems to break apt's progress bar, which causes
  a mess when apt tries to print one. Moving to apt-get worked around
  this problem and should make CI log more pleasent to look at.