### PR TITLE
android9: mount tmpfs over /mnt/vendor

### DIFF
--- a/android9/overlay/etc/init/mount-android.conf
+++ b/android9/overlay/etc/init/mount-android.conf
@@ -13,6 +13,9 @@ script
     mkdir -p /dev/cpuset
     mount none /dev/cpuset -t cpuset -o nodev,noexec,nosuid
 
+    # mount tmpfs so vendor-specific mountpoints can be created
+    mount tmpfs -t tmpfs /mnt/vendor
+
     /usr/sbin/mount-android.sh
 
     if [ -d /android/metadata ]; then


### PR DESCRIPTION
This matches what Android does and allows mount-android.sh to create correct vendor-specific mount points since rootfs is read-only.